### PR TITLE
Proxy the Application Insights query via the ibex-server

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -11,6 +11,7 @@ const apiRouter = require('./routes/api');
 const graphQLRouter = require('./routes/graphql');
 const cosmosDBRouter = require('./routes/cosmos-db');
 const azureRouter = require('./routes/azure');
+const appInsightsRouter = require('./routes/application-insights');
 
 const app = express();
 
@@ -34,6 +35,7 @@ app.use('/api', apiRouter.router);
 app.use('/cosmosdb', cosmosDBRouter.router);
 app.use('/azure', azureRouter.router);
 app.use('/graphql', graphQLRouter.router)
+app.use('/applicationinsights', appInsightsRouter.router)
 
 app.use(express.static(path.resolve(__dirname, '..', 'build')));
 

--- a/server/routes/application-insights.js
+++ b/server/routes/application-insights.js
@@ -5,8 +5,7 @@ const router = new express.Router();
 const host = 'api.applicationinsights.io';
 
 router.post('/query', (req, res) => {
-  const { apiKey, appId, query } = req.body;
-  const queryTimespan = req.query['timespan'];
+  const { apiKey, appId, query, queryTimespan } = req.body;
 
   if (!apiKey || !appId) {
     return res.send({ error: 'Invalid request parameters' });

--- a/server/routes/application-insights.js
+++ b/server/routes/application-insights.js
@@ -8,7 +8,7 @@ router.post('/query', (req, res) => {
   const { apiKey, appId, query, queryTimespan } = req.body;
 
   if (!apiKey || !appId) {
-    return res.send({ error: 'Invalid request parameters' });
+    return res.send({ error: 'Invalid request parameters: API key and app ID are required' });
   }
 
   let url = `https://${host}/beta/apps/${appId}/query`;

--- a/server/routes/application-insights.js
+++ b/server/routes/application-insights.js
@@ -4,10 +4,8 @@ const router = new express.Router();
 
 const host = 'api.applicationinsights.io';
 
-router.post('/:appId/query', (req, res) => {
-  const apiKey = req.headers['x-api-key'];
-  const { appId } = req.params;
-  const { query } = req.body;
+router.post('/query', (req, res) => {
+  const { apiKey, appId, query } = req.body;
   const queryTimespan = req.query['timespan'];
 
   if (!apiKey || !appId) {

--- a/server/routes/application-insights.js
+++ b/server/routes/application-insights.js
@@ -25,7 +25,6 @@ router.post('/query', (req, res) => {
     json: true,
   }, (err, result) => {
     if (err) {
-      console.log(err);
       return res.send({ error: err });
     }
     res.send(result);

--- a/server/routes/application-insights.js
+++ b/server/routes/application-insights.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const request = require('xhr-request');
+const router = new express.Router();
+
+const host = 'api.applicationinsights.io';
+
+router.post('/:appId/query', (req, res) => {
+  const apiKey = req.headers['x-api-key'];
+  const { appId } = req.params;
+  const { query } = req.body;
+  const queryTimespan = req.query['timespan'];
+
+  if (!apiKey || !appId) {
+    return res.send({ error: 'Invalid request parameters' });
+  }
+
+  let url = `https://${host}/beta/apps/${appId}/query`;
+  if (queryTimespan) url += `?timespan=${queryTimespan}`;
+
+  request(url, {
+    method: 'POST',
+    headers: {
+      'x-api-key': apiKey,
+    },
+    body: {
+      query,
+    },
+    json: true,
+  }, (err, result) => {
+    if (err) {
+      console.log(err);
+      return res.send({ error: err });
+    }
+    res.send(result);
+  });
+
+});
+
+module.exports = {
+  router,
+};

--- a/src/data-sources/plugins/ApplicationInsights/ApplicationInsightsApi.ts
+++ b/src/data-sources/plugins/ApplicationInsights/ApplicationInsightsApi.ts
@@ -11,18 +11,18 @@ export default class ApplicationInsightsApi implements IApplicationInsightsApi {
   constructor(private appId: string, private apiKey: string) { }
   
   callQuery(query: string, callback: (error?: Error, json?: any) => void) {
-    var url = `${appInsightsUri}/${this.appId}/query`; 
     try {
       request(
-        url, 
+        `${appInsightsUri}/query`,
         {
           method: 'POST',
           json: true,
-          headers: {
-            'x-api-key': this.apiKey
+          body: {
+            apiKey: this.apiKey,
+            appId: this.appId,
+            query,
           },
-          body: { query }
-        }, 
+        },
         (error: Error, json: any) => {
           if (error) {
             callback(error);

--- a/src/data-sources/plugins/ApplicationInsights/Query.ts
+++ b/src/data-sources/plugins/ApplicationInsights/Query.ts
@@ -95,21 +95,18 @@ export default class ApplicationInsightsQuery extends DataSourcePlugin<IQueryPar
       });
     }
 
-    var url = `${appInsightsUri}/${appId}/query?timespan=${queryTimespan}`;
-
     return (dispatch) => {
       request(
-        url, 
+        `${appInsightsUri}/query?timespan=${queryTimespan}`,
         {
           method: 'POST',
           json: true,
-          headers: {
-            'x-api-key': apiKey
-          },
           body: {
-            query
-          }
-        }, 
+            appId,
+            apiKey,
+            query,
+          },
+        },
         (error, json) => {
           if (error) { return this.failure(error); }
           if (json.error) {

--- a/src/data-sources/plugins/ApplicationInsights/Query.ts
+++ b/src/data-sources/plugins/ApplicationInsights/Query.ts
@@ -97,11 +97,12 @@ export default class ApplicationInsightsQuery extends DataSourcePlugin<IQueryPar
 
     return (dispatch) => {
       request(
-        `${appInsightsUri}/query?timespan=${queryTimespan}`,
+        `${appInsightsUri}/query`,
         {
           method: 'POST',
           json: true,
           body: {
+            queryTimespan,
             appId,
             apiKey,
             query,

--- a/src/data-sources/plugins/ApplicationInsights/common.ts
+++ b/src/data-sources/plugins/ApplicationInsights/common.ts
@@ -1,7 +1,11 @@
+// for some reason this needs to have the scheme, host and port specified
+// using just /applicationinsights means that the nock tests fail
+// hard-coding these values is not ideal but will get fixed when eladiw@
+// finishes refactoring the server setup/configuration
+const appInsightsUri = 'http://localhost:3000/applicationinsights';
 
-var appInsightsUri = 'https://api.applicationinsights.io/beta/apps';
-var appId = process.env.REACT_APP_APP_INSIGHTS_APPID;
-var apiKey = process.env.REACT_APP_APP_INSIGHTS_APIKEY;
+const appId = process.env.REACT_APP_APP_INSIGHTS_APPID;
+const apiKey = process.env.REACT_APP_APP_INSIGHTS_APIKEY;
 
 export {
   appInsightsUri,

--- a/src/tests/data-sources/ApplicationInsights.Query.Forked.test.ts
+++ b/src/tests/data-sources/ApplicationInsights.Query.Forked.test.ts
@@ -1,7 +1,7 @@
 import { IDataSourceDictionary } from '../../data-sources';
 import { setupTests } from '../utils/setup';
 
-import { mockRequests } from '../mocks/requests/application-insights';
+import { mock24hoursAppInsightsRequest, mock30daysAppInsightsRequest } from '../mocks/requests/application-insights';
 import dashboardMock from '../mocks/dashboards/application-insights-forked';
 
 describe('Data Source: Application Insights: Forked Query', () => {
@@ -9,12 +9,12 @@ describe('Data Source: Application Insights: Forked Query', () => {
   let dataSources: IDataSourceDictionary = {};
 
   beforeAll(() => {
-
-    mockRequests();
     dataSources = setupTests(dashboardMock);
   });
 
   it ('Query for 30 days with data rows', () => {
+    mock30daysAppInsightsRequest();
+
     expect(dataSources).toHaveProperty('events');
     expect(dataSources.timespan).toHaveProperty('store');
     expect(dataSources.events).toHaveProperty('store');
@@ -43,6 +43,7 @@ describe('Data Source: Application Insights: Forked Query', () => {
   });
 
   it ('Query for 24 hours with 0 rows', () => {
+    mock24hoursAppInsightsRequest();
     dataSources.timespan.action.updateSelectedValue.defer('24 hours');
 
     return new Promise((resolve, reject) => {

--- a/src/tests/data-sources/ApplicationInsights.Query.Forked.test.ts
+++ b/src/tests/data-sources/ApplicationInsights.Query.Forked.test.ts
@@ -1,6 +1,5 @@
 import { IDataSourceDictionary } from '../../data-sources';
 import { setupTests } from '../utils/setup';
-import { appInsightsUri } from '../../data-sources/plugins/ApplicationInsights/common';
 
 import { mockRequests } from '../mocks/requests/application-insights';
 import dashboardMock from '../mocks/dashboards/application-insights-forked';

--- a/src/tests/data-sources/ApplicationInsights.Query.Forked.test.ts
+++ b/src/tests/data-sources/ApplicationInsights.Query.Forked.test.ts
@@ -14,7 +14,7 @@ describe('Data Source: Application Insights: Forked Query', () => {
     dataSources = setupTests(dashboardMock);
   });
 
-  it ('Query for 30 months with data rows', () => {
+  it ('Query for 30 days with data rows', () => {
     
     expect(dataSources).toHaveProperty('events');
     expect(dataSources.timespan).toHaveProperty('store');

--- a/src/tests/data-sources/ApplicationInsights.Query.Forked.test.ts
+++ b/src/tests/data-sources/ApplicationInsights.Query.Forked.test.ts
@@ -15,7 +15,6 @@ describe('Data Source: Application Insights: Forked Query', () => {
   });
 
   it ('Query for 30 days with data rows', () => {
-    
     expect(dataSources).toHaveProperty('events');
     expect(dataSources.timespan).toHaveProperty('store');
     expect(dataSources.events).toHaveProperty('store');

--- a/src/tests/data-sources/ApplicationInsights.Query.test.ts
+++ b/src/tests/data-sources/ApplicationInsights.Query.test.ts
@@ -2,7 +2,7 @@ import { IDataSourceDictionary } from '../../data-sources';
 import { setupTests } from '../utils/setup';
 import { appInsightsUri } from '../../data-sources/plugins/ApplicationInsights/common';
 
-import { mockRequests } from '../mocks/requests/application-insights';
+import { mock24hoursAppInsightsRequest, mock30daysAppInsightsRequest } from '../mocks/requests/application-insights';
 import dashboardMock from '../mocks/dashboards/application-insights';
 
 describe('Data Source: Application Insights: Query', () => {
@@ -10,12 +10,12 @@ describe('Data Source: Application Insights: Query', () => {
   let dataSources: IDataSourceDictionary = {};
 
   beforeAll(() => {
-
-    mockRequests();
     dataSources = setupTests(dashboardMock);
   });
 
   it ('Query for 30 days with data rows', () => {
+    mock30daysAppInsightsRequest();
+
     expect(dataSources).toHaveProperty('events');
     expect(dataSources.timespan).toHaveProperty('store');
     expect(dataSources.events).toHaveProperty('store');
@@ -43,6 +43,7 @@ describe('Data Source: Application Insights: Query', () => {
   });
 
   it ('Query for 24 hours with 0 rows', () => {
+    mock24hoursAppInsightsRequest();
     dataSources.timespan.action.updateSelectedValue.defer('24 hours');
 
     return new Promise((resolve, reject) => {

--- a/src/tests/data-sources/ApplicationInsights.Query.test.ts
+++ b/src/tests/data-sources/ApplicationInsights.Query.test.ts
@@ -1,6 +1,5 @@
 import { IDataSourceDictionary } from '../../data-sources';
 import { setupTests } from '../utils/setup';
-import { appInsightsUri } from '../../data-sources/plugins/ApplicationInsights/common';
 
 import { mock24hoursAppInsightsRequest, mock30daysAppInsightsRequest } from '../mocks/requests/application-insights';
 import dashboardMock from '../mocks/dashboards/application-insights';

--- a/src/tests/data-sources/ApplicationInsights.Query.test.ts
+++ b/src/tests/data-sources/ApplicationInsights.Query.test.ts
@@ -15,7 +15,7 @@ describe('Data Source: Application Insights: Query', () => {
     dataSources = setupTests(dashboardMock);
   });
 
-  it ('Query for 30 months with data rows', () => {
+  it ('Query for 30 days with data rows', () => {
     
     expect(dataSources).toHaveProperty('events');
     expect(dataSources.timespan).toHaveProperty('store');

--- a/src/tests/data-sources/ApplicationInsights.Query.test.ts
+++ b/src/tests/data-sources/ApplicationInsights.Query.test.ts
@@ -16,7 +16,6 @@ describe('Data Source: Application Insights: Query', () => {
   });
 
   it ('Query for 30 days with data rows', () => {
-    
     expect(dataSources).toHaveProperty('events');
     expect(dataSources.timespan).toHaveProperty('store');
     expect(dataSources.events).toHaveProperty('store');

--- a/src/tests/mocks/requests/application-insights/index.ts
+++ b/src/tests/mocks/requests/application-insights/index.ts
@@ -11,19 +11,15 @@ const { appId, apiKey } = dashboardMock.config.connections['application-insights
  */
 function mockRequests() {
 
-  nock(appInsightsUri, {
-    reqheaders: {
-      "x-api-key": apiKey
-    }
-  })
-    .post(`/${appId}/query?timespan=PT24H`)
-    .delay(100)
-    .reply(200, query24HResponseMock)
-    .post(`/${appId}/query?timespan=P30D`)
-    .delay(100)
-    .reply(200, query30DResponseMock);
-
+  nock(appInsightsUri)
+  .post(`/query?timespan=PT24H`)
+  .delay(100)
+  .reply(200, query24HResponseMock)
+  .post(`/query?timespan=P30D`)
+  .delay(100)
+  .reply(200, query30DResponseMock);
 }
+
 export {
   mockRequests
 };

--- a/src/tests/mocks/requests/application-insights/index.ts
+++ b/src/tests/mocks/requests/application-insights/index.ts
@@ -6,20 +6,21 @@ import { appInsightsUri } from '../../../../data-sources/plugins/ApplicationInsi
 
 const { appId, apiKey } = dashboardMock.config.connections['application-insights'];
 
-/**
- * Mocking application insights requets
- */
-function mockRequests() {
-
+function mock24hoursAppInsightsRequest() {
   nock(appInsightsUri)
   .post(`/query?timespan=PT24H`)
   .delay(100)
   .reply(200, query24HResponseMock)
+}
+
+function mock30daysAppInsightsRequest() {
+  nock(appInsightsUri)
   .post(`/query?timespan=P30D`)
   .delay(100)
   .reply(200, query30DResponseMock);
 }
 
 export {
-  mockRequests
+  mock24hoursAppInsightsRequest,
+  mock30daysAppInsightsRequest,
 };

--- a/src/tests/mocks/requests/application-insights/index.ts
+++ b/src/tests/mocks/requests/application-insights/index.ts
@@ -8,14 +8,14 @@ const { appId, apiKey } = dashboardMock.config.connections['application-insights
 
 function mock24hoursAppInsightsRequest() {
   nock(appInsightsUri)
-  .post(`/query?timespan=PT24H`)
+  .post(`/query`)
   .delay(100)
   .reply(200, query24HResponseMock)
 }
 
 function mock30daysAppInsightsRequest() {
   nock(appInsightsUri)
-  .post(`/query?timespan=P30D`)
+  .post(`/query`)
   .delay(100)
   .reply(200, query30DResponseMock);
 }


### PR DESCRIPTION
Currently, we're in an inconsistent state where almost all the data-source plugins in the ibex-client fetch data by calling the ibex-server which in turn talks to the backend data source... except for Application Insights which the client fetches by directly talking to the backend and skipping the server.

The current situation looks like this:

![Data fetching pipeline, status quo](https://user-images.githubusercontent.com/1086421/27184562-d4383a00-51e2-11e7-9f21-2100fd83cf98.png)

This pull request fixes the inconsistency. This does introduce an additional http connection from the ibex-client to the ibex-server, however, that cost is well worth it for the following reasons:

1) Consistent handling of all the data sources
2) Option to change the application insights implementation (important when we'll move to Apollo)
3) Ability to separate the frontend from the backend, e.g. so that they can be deployed separately (@eladiw  is working on this, this pull request is a pre-condition for his work)

After merging the pull request, the diagram above will be made consistent:

![Data fetching pipeline, after merge](https://user-images.githubusercontent.com/1086421/27184586-e5fda252-51e2-11e7-9c99-2ec77933ea45.png)
