### PR TITLE
Itye/create persistent folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ibex Dashboard [![Build Status](https://travis-ci.org/CatalystCode/ibex-dashboard.png?branch=master)](https://travis-ci.org/CatalystCode/ibex-dashboard)
 
 > Notice: This repo is in the process of moving into a new home. We will update once this happens in this page.
-> Notice: Version 1.2 breaks the persitency paths of data. If you are upgrading to this version, simply copy your files from `/dashboards` into `/dashboards/persistent/` while keeping the same internal directory structure.
+> Notice: Version 1.2 breaks the persitency paths of data. If you are upgrading to this version, simply copy your generate files from `/dashboards` into `/dashboards/persistent/` as follows: `private files: *.private.js` should be placed in the `/dashboards/persistent/private` folder, and `private templates: *.private.ts` should be placed in the `/dashboards/persistent/customTemplates` folder.
 
 [Ibex](http://aka.ms/ibex) is a dashboarding application that enables building dashboard and templates.
 It mainly supports **Application Insights** but data sources and visual components are easily extendable.

--- a/README.md
+++ b/README.md
@@ -2,12 +2,17 @@
 
 > Notice: This repo is in the process of moving into a new home. We will update once this happens in this page.
 
-> Notice: Version 1.2 breaks the persitency paths of data. If you are upgrading to this version, simply copy your generate files from `/dashboards` into `/dashboards/persistent/` as follows: 
-> `private files: *.private.js` should be placed in the `/dashboards/persistent/private` folder, and 
-> `private templates: *.private.ts` should be placed in the `/dashboards/persistent/customTemplates` folder.
-
 [Ibex](http://aka.ms/ibex) is a dashboarding application that enables building dashboard and templates.
 It mainly supports **Application Insights** but data sources and visual components are easily extendable.
+
+## Changes
+
+### Version 1.2 (October 16, 2017)
+Version 1.2 breaks the persitency paths of dashboard files and custom templates. If you are upgrading to this version, copy your private dashboards from `/dashboards` into `/dashboards/persistent/` as follows: 
+
+> Private Files: Move files from `/dashboards/*.private.js` to `/dashboards/persistent/private`.
+
+> Custom Templates: Move files from `/dashboards/customTemplates/*.private.ts` to `/dashboards/persistent/customTemplates`.
 
 # Preview
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Ibex Dashboard [![Build Status](https://travis-ci.org/CatalystCode/ibex-dashboard.png?branch=master)](https://travis-ci.org/CatalystCode/ibex-dashboard)
 
 > Notice: This repo is in the process of moving into a new home. We will update once this happens in this page.
+> Notice: Version 1.2 breaks the persitency paths of data. If you are upgrading to this version, simply copy your files from `/dashboards` into `/dashboards/persistent/` while keeping the same internal directory structure.
 
 [Ibex](http://aka.ms/ibex) is a dashboarding application that enables building dashboard and templates.
 It mainly supports **Application Insights** but data sources and visual components are easily extendable.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Ibex Dashboard [![Build Status](https://travis-ci.org/CatalystCode/ibex-dashboard.png?branch=master)](https://travis-ci.org/CatalystCode/ibex-dashboard)
 
 > Notice: This repo is in the process of moving into a new home. We will update once this happens in this page.
+
 > Notice: Version 1.2 breaks the persitency paths of data. If you are upgrading to this version, simply copy your generate files from `/dashboards` into `/dashboards/persistent/` as follows: 
 > `private files: *.private.js` should be placed in the `/dashboards/persistent/private` folder, and 
 > `private templates: *.private.ts` should be placed in the `/dashboards/persistent/customTemplates` folder.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Ibex Dashboard [![Build Status](https://travis-ci.org/CatalystCode/ibex-dashboard.png?branch=master)](https://travis-ci.org/CatalystCode/ibex-dashboard)
 
 > Notice: This repo is in the process of moving into a new home. We will update once this happens in this page.
-> Notice: Version 1.2 breaks the persitency paths of data. If you are upgrading to this version, simply copy your generate files from `/dashboards` into `/dashboards/persistent/` as follows: `private files: *.private.js` should be placed in the `/dashboards/persistent/private` folder, and `private templates: *.private.ts` should be placed in the `/dashboards/persistent/customTemplates` folder.
+> Notice: Version 1.2 breaks the persitency paths of data. If you are upgrading to this version, simply copy your generate files from `/dashboards` into `/dashboards/persistent/` as follows: 
+> `private files: *.private.js` should be placed in the `/dashboards/persistent/private` folder, and 
+> `private templates: *.private.ts` should be placed in the `/dashboards/persistent/customTemplates` folder.
 
 [Ibex](http://aka.ms/ibex) is a dashboarding application that enables building dashboard and templates.
 It mainly supports **Application Insights** but data sources and visual components are easily extendable.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ibex-dashboard",
-  "version": "0.1.0",
+  "version": "1.2.0",
   "private": true,
   "dependencies": {
     "npm-run-all": "^4.0.2"

--- a/server/routes/api.js
+++ b/server/routes/api.js
@@ -46,9 +46,9 @@ const getMetadata = (text) => {
 }
 
 const paths = () => ({
-  privateDashboard: path.join(__dirname, '..', 'dashboards'),
+  privateDashboard: path.join(__dirname, '..', 'dashboards','persistent','private'),
   preconfDashboard: path.join(__dirname, '..', 'dashboards', 'preconfigured'),
-  privateTemplate: path.join(__dirname, '..', 'dashboards', 'customTemplates')
+  privateTemplate: path.join(__dirname, '..', 'dashboards','persistent', 'customTemplates')
 });
 
 const isValidFile = (filePath) => {
@@ -63,8 +63,12 @@ const getFileContents = (filePath) => {
     : contents;
 }
 
-const ensureCustomTemplatesFolderExists = () => {
-  const { privateTemplate } = paths();
+const ensureCustomFoldersExists = () => {
+  const { privateTemplate, privateDashboard } = paths();
+
+  if (!fs.existsSync(privateDashboard)) {
+    fs.mkdirSync(privateDashboard);
+  }
 
   if (!fs.existsSync(privateTemplate)) {
     fs.mkdirSync(privateTemplate);
@@ -72,7 +76,7 @@ const ensureCustomTemplatesFolderExists = () => {
 }
 
 router.get('/dashboards', (req, res) => {
-
+  ensureCustomFoldersExists();
   const { privateDashboard, preconfDashboard, privateTemplate } = paths();
 
   let script = '';
@@ -134,7 +138,6 @@ router.get('/dashboards', (req, res) => {
     });
   }
 
-  ensureCustomTemplatesFolderExists();
   let customTemplates = fs.readdirSync(privateTemplate);
   if (customTemplates && customTemplates.length) {
     customTemplates.forEach((fileName) => {
@@ -195,7 +198,7 @@ router.get('/dashboards/:id*', (req, res) => {
 router.post('/dashboards/:id', (req, res) => {
   let { id } = req.params;
   let { script } = req.body || '';
-
+  ensureCustomFoldersExists();
   const { privateDashboard } = paths();
   let dashboardFile = getFileById(privateDashboard, id);
   let filePath = path.join(privateDashboard, dashboardFile);
@@ -213,7 +216,7 @@ router.post('/dashboards/:id', (req, res) => {
 router.get('/templates/:id', (req, res) => {
 
   let templateId = req.params.id;
-  let templatePath = path.join(__dirname, '..', 'dashboards', 'preconfigured');
+  let templatePath = paths().preconfDashboard;
 
   let script = '';
 
@@ -221,7 +224,7 @@ router.get('/templates/:id', (req, res) => {
 
   if (!templateFile) {
     //fallback to custom template
-    templatePath = path.join(__dirname, '..', 'dashboards', 'customTemplates');
+    templatePath = paths().privateTemplate;
     templateFile = getFileById(templatePath, templateId);
   }
   if (templateFile) {
@@ -254,7 +257,7 @@ router.put('/templates/:id', (req, res) => {
 
   const { privateTemplate } = paths();
 
-  ensureCustomTemplatesFolderExists();
+  ensureCustomFoldersExists();
 
   let templatePath = path.join(privateTemplate, id + '.private.ts');
   let templateFile = getFileById(privateTemplate, id);


### PR DESCRIPTION
Separated the pre-configured templates folder from the user generated dashboard files, in order to allow mounting the custom files path to be outside of the server, for persistence.
The new folder tree is:
/server/dashboards/preconfigured
/server/dashboards/persistent/private
/server/dashboards/persistent/customTemplates

The path "/server/dashboards/persistent/" will allow to be mounted,if necessary, outside of the server.