### PR TITLE
Fixed bug with preselected values in MenuFilter

### DIFF
--- a/client/src/components/generic/MenuFilter.tsx
+++ b/client/src/components/generic/MenuFilter.tsx
@@ -55,7 +55,7 @@ export default class MenuFilter extends GenericComponent<any, any> {
 
   static fromSource(source: string) {
     return {
-      selectedValue: GenericComponent.sourceFormat(source, 'values-selected'), 
+      selectedValues: GenericComponent.sourceFormat(source, 'values-selected'), 
       values: GenericComponent.sourceFormat(source, 'values-all')
     };
   }


### PR DESCRIPTION
Fixed a bug when you supply `selectedValues` to a `MenuFilter` via a datasource.

The fromSource function was probably copied over from `TextFilter`, but `MenuFilter` uses the plural definition since it allows to filter on multiple values.